### PR TITLE
Highlight instances of `mode $variableName`

### DIFF
--- a/syntaxes/i3.tmLanguage
+++ b/syntaxes/i3.tmLanguage
@@ -19,6 +19,25 @@
     <array>
       <dict>
         <key>name</key>
+        <string>mode_variable_name</string>
+        <key>match</key>
+        <string>(mode)\s+(\$?\w*)</string>
+        <key>captures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.control.i3</string>
+          </dict>
+          <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>variable.other.i3</string>
+          </dict>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
         <string>criteria</string>
         <key>match</key>
         <string>\[(\w+)=(\&quot;.*\&quot;)\]</string>


### PR DESCRIPTION
Using binding `mode`s in combination with `$variableName`s is common practice and [recommended by i3's documentation](https://i3wm.org/docs/userguide.html#binding_modes). 

Without this change, these instances are not highlighted:
![image](https://github.com/dcasella/i3wm-syntax/assets/14939129/adc2429f-eb34-449f-b302-dc8e83a211e8)

After this change:
![image](https://github.com/dcasella/i3wm-syntax/assets/14939129/6aac439b-6728-4aca-a709-431b8a626d5f)
_Note the `mode $prtscMode` in second and the last line._