### PR TITLE
Highlight instances of `border normal`

### DIFF
--- a/syntaxes/i3.tmLanguage
+++ b/syntaxes/i3.tmLanguage
@@ -2284,7 +2284,7 @@
         <key>name</key>
         <string>border_style</string>
         <key>match</key>
-        <string>(border)\s*(none|normal(\s*\d+)?|toggle(\s*\d+)?|pixel(\s*\d+)?)</string>
+        <string>(border)\s*(none|1pixel|normal(\s*\d+)?|toggle(\s*\d+)?|pixel(\s*\d+)?)</string>
         <key>captures</key>
         <dict>
           <key>1</key>

--- a/syntaxes/i3.tmLanguage
+++ b/syntaxes/i3.tmLanguage
@@ -2282,9 +2282,9 @@
       </dict>
       <dict>
         <key>name</key>
-        <string>border</string>
+        <string>border_style</string>
         <key>match</key>
-        <string>(border)\s*(none|toggle|(\d+)\s*pixel|(?:pixel|normal)\s*(\d+))</string>
+        <string>(border)\s*(none|normal(\s*\d+)?|toggle(\s*\d+)?|pixel(\s*\d+)?)</string>
         <key>captures</key>
         <dict>
           <key>1</key>
@@ -2298,6 +2298,16 @@
             <string>constant.language.i3</string>
           </dict>
           <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>constant.numeric.i3</string>
+          </dict>
+          <key>4</key>
+          <dict>
+            <key>name</key>
+            <string>constant.numeric.i3</string>
+          </dict>
+          <key>5</key>
           <dict>
             <key>name</key>
             <string>constant.numeric.i3</string>


### PR DESCRIPTION
This patch attempts to cover all the possible `border` styling options as it's described in [6.17. Changing border style](https://i3wm.org/docs/userguide.html#_changing_border_style).


**Before:**
![image](https://github.com/a-pav/i3wm-syntax/assets/14939129/0b5139a9-6f91-4c04-9930-b0e181d80ba7)
<details>
<summary>More <b>before</b> tests:</summary>

- As you see, some invalid configs are highlighted while some correct ones are not.

![image](https://github.com/a-pav/i3wm-syntax/assets/14939129/69aa9bcf-a164-4725-8ddc-6fc50344652f)

</details>

**After:**
![image](https://github.com/a-pav/i3wm-syntax/assets/14939129/a75b8e9d-9793-459a-ad24-4e76883460b5)

<details>
<summary>More <b>after</b> tests:</summary>

- All valid configs are highlighted while all the invalid ones are not.

![image](https://github.com/a-pav/i3wm-syntax/assets/14939129/f3ee2c6b-00f7-4ce3-aa23-e4a610f7a132)

</details>

Please note that `bordernormal` and `border normal`, though not mentioned in the documentation, are both correct configs and accepted by i3!

Also, as noted by the documentation, `border 1pixel` is indeed the legacy and equivalent syntax for `border pixel 1`, BUT `border <n>pixel` is _invalid config_ and NOT equivalent to `border pixel <n>` where `n > 1`! (i3 version `4.20.1 (2021-11-03)`)

So with this patch, there would be no highlighting for these:
```sh
for_window [class="Gnome-calculator"] border 1pixel # special legacy syntax.
for_window [class="Gnome-calculator"] border 2pixel # invalid config.
```


<!-- 
test cases:

```
for_window [class="Gnome-calculator"] border 20 # invalid config.
for_window [class="Gnome-calculator"] border none
for_window [class="Gnome-calculator"] bordernone
for_window [class="Gnome-calculator"] border normal
for_window [class="Gnome-calculator"] bordernormal
for_window [class="Gnome-calculator"] border normal 20
for_window [class="Gnome-calculator"] bordernormal20
for_window [class="Gnome-calculator"] border 20 normal # invalid config.
for_window [class="Gnome-calculator"] border toggle
for_window [class="Gnome-calculator"] bordertoggle
for_window [class="Gnome-calculator"] border toggle 20
for_window [class="Gnome-calculator"] bordertoggle20
for_window [class="Gnome-calculator"] border 20 toggle # invalid config.
for_window [class="Gnome-calculator"] border pixel
for_window [class="Gnome-calculator"] border pixel 20
for_window [class="Gnome-calculator"] borderpixel20
for_window [class="Gnome-calculator"] border 20 pixel # invalid config.
for_window [class="Gnome-calculator"] border 1pixel
for_window [class="Gnome-calculator"] border 20pixel # invalid config.

```
-->